### PR TITLE
feat(ci): run integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,22 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
           chmod +x ~/.docker/cli-plugins/docker-compose
       - run: make test
+
+  test-jaeger-grpc-integration:
+    name: test-jaeger-grpc-integration
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials from CI account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::962548656022:role/jaeger-s3-ci
+          aws-region: us-east-1
+      - run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+      - run: make test-jaeger-grpc-integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-test-config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM code AS test
 
 FROM base AS jaeger-grpc-integration
 ARG GOARCH=amd64
-RUN git clone --depth=1 --single-branch --branch=main https://github.com/jaegertracing/jaeger.git /jaeger
+RUN git clone --depth=1 --single-branch --branch=no-future https://github.com/johanneswuerbach/jaeger.git /jaeger
 WORKDIR /jaeger
 COPY --from=build /src/s3-plugin /go/bin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       - STORAGE=grpc-plugin
       - AWS_PROFILE
       - AWS_REGION
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
     volumes:
       - ~/.aws:/root/.aws
       - int-mod-cache:/go/pkg/mod

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,0 +1,13 @@
+s3:
+  bucketName: jaeger-s3-test
+  prefix: spans/
+  bufferDuration: 1s
+  emptyBucket: true
+athena:
+  databaseName: default
+  tableName: jaeger
+  outputLocation: s3://jaeger-s3-test-results/
+  workGroup: jaeger
+  maxSpanAge: 336h
+  dependenciesQueryTtl: 6h
+  servicesQueryTtl: 10s


### PR DESCRIPTION
Run the upstream [GRPC integration tests](https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/integration/grpc_test.go#L141) using real AWS service to ensure everything works end-to-end.