### PR TITLE
feat: improved cache lookup

### DIFF
--- a/plugin/s3spanstore/athena_query_cache.go
+++ b/plugin/s3spanstore/athena_query_cache.go
@@ -2,90 +2,122 @@ package s3spanstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/sync/errgroup"
 )
 
 type AthenaQueryCache struct {
+	logger    hclog.Logger
 	svc       AthenaAPI
 	workGroup string
 }
 
-func NewAthenaQueryCache(svc AthenaAPI, workGroup string) *AthenaQueryCache {
-	return &AthenaQueryCache{svc: svc, workGroup: workGroup}
+func NewAthenaQueryCache(logger hclog.Logger, svc AthenaAPI, workGroup string) *AthenaQueryCache {
+	return &AthenaQueryCache{logger: logger, svc: svc, workGroup: workGroup}
 }
 
 func (c *AthenaQueryCache) Lookup(ctx context.Context, key string, ttl time.Duration) (*types.QueryExecution, error) {
-	paginator := athena.NewListQueryExecutionsPaginator(c.svc, &athena.ListQueryExecutionsInput{
-		WorkGroup: &c.workGroup,
-	})
-	queryExecutionIds := []string{}
-	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get athena query result: %w", err)
+	ttlTime := time.Now().Add(-ttl)
+	queryExecutionIdChunks := make(chan []string, 3)
+
+	g, gCtx := errgroup.WithContext(ctx)
+	fetchCtx, fetchCancelFunc := context.WithCancel(gCtx)
+
+	// Page fetcher
+	g.Go(func() error {
+		paginator := athena.NewListQueryExecutionsPaginator(c.svc, &athena.ListQueryExecutionsInput{
+			WorkGroup:  &c.workGroup,
+			MaxResults: aws.Int32(50),
+		})
+
+		pages := 0
+		earlyExit := false
+		defer close(queryExecutionIdChunks)
+
+	Pages:
+		for paginator.HasMorePages() {
+			pages += 1
+			output, err := paginator.NextPage(fetchCtx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					earlyExit = true
+					break Pages
+				}
+
+				return fmt.Errorf("failed to get athena query result: %w", err)
+			}
+
+			select {
+			case <-fetchCtx.Done():
+				earlyExit = true
+				break Pages
+			case queryExecutionIdChunks <- output.QueryExecutionIds:
+			}
 		}
 
-		queryExecutionIds = append(queryExecutionIds, output.QueryExecutionIds...)
-	}
+		c.logger.Debug("AthenaQueryCache/ListQueryExecutions finished", "pages", pages, "earlyExit", earlyExit)
 
-	queryExecutionIdChunks := chunks(queryExecutionIds, 50)
-	g, getQueryExecutionCtx := errgroup.WithContext(ctx)
+		return nil
+	})
 
-	ttlTime := time.Now().Add(-ttl)
-	var mu sync.Mutex
-
+	// QueryExecutions lookup worker
 	var latestQueryExecution *types.QueryExecution
+	g.Go(func() error {
+		executionsFetched := 0
+		found := false
 
-	for _, value := range queryExecutionIdChunks {
-		value := value
-		g.Go(func() error {
-			result, err := c.svc.BatchGetQueryExecution(getQueryExecutionCtx, &athena.BatchGetQueryExecutionInput{
-				QueryExecutionIds: value,
+		select {
+		case <-fetchCtx.Done():
+			break
+		case queryExecutionIds := <-queryExecutionIdChunks:
+			if len(queryExecutionIds) == 0 {
+				fetchCancelFunc() // Cancel search as results are ordered, so this is the most recent
+				break
+			}
+
+			result, err := c.svc.BatchGetQueryExecution(gCtx, &athena.BatchGetQueryExecutionInput{
+				QueryExecutionIds: queryExecutionIds,
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get query executions: %w", err)
 			}
 
+			executionsFetched += len(result.QueryExecutions)
 			for _, v := range result.QueryExecutions {
-				// Different query
-				if !strings.Contains(*v.Query, key) {
-					continue
-				}
-
-				// Query didn't completed
-				if v.Status.CompletionDateTime == nil {
-					continue
-				}
-
 				// Query already expired
-				if v.Status.CompletionDateTime.Before(ttlTime) {
+				if v.Status.SubmissionDateTime.Before(ttlTime) {
+					fetchCancelFunc() // Cancel search as results are ordered so no more recent query wll follow
 					continue
 				}
 
-				mu.Lock()
-
-				// Store the latest query result
-				if latestQueryExecution == nil {
-					latestQueryExecution = &v
-				} else {
-					if v.Status.CompletionDateTime.After(*latestQueryExecution.Status.CompletionDateTime) {
-						latestQueryExecution = &v
-					}
+				// We don't want to match unsuccessful executions
+				if v.Status.State == "FAILED" || v.Status.State == "CANCELLED" {
+					continue
 				}
 
-				mu.Unlock()
+				// Matching query
+				if strings.Contains(*v.Query, key) {
+					found = true
+					latestQueryExecution = &v
+					fetchCancelFunc() // Cancel search as results are ordered, so this is the most recent
+					break
+				}
 			}
+		}
 
-			return nil
-		})
-	}
+		c.logger.Debug("AthenaQueryCache/BatchGetQueryExecution finished", "executionsFetched", executionsFetched, "found", found)
+
+		return nil
+	})
+
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}

--- a/plugin/s3spanstore/athena_query_cache.go
+++ b/plugin/s3spanstore/athena_query_cache.go
@@ -1,0 +1,94 @@
+package s3spanstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"golang.org/x/sync/errgroup"
+)
+
+type AthenaQueryCache struct {
+	svc       AthenaAPI
+	workGroup string
+}
+
+func NewAthenaQueryCache(svc AthenaAPI, workGroup string) *AthenaQueryCache {
+	return &AthenaQueryCache{svc: svc, workGroup: workGroup}
+}
+
+func (c *AthenaQueryCache) Lookup(ctx context.Context, key string, ttl time.Duration) (*types.QueryExecution, error) {
+	paginator := athena.NewListQueryExecutionsPaginator(c.svc, &athena.ListQueryExecutionsInput{
+		WorkGroup: &c.workGroup,
+	})
+	queryExecutionIds := []string{}
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get athena query result: %w", err)
+		}
+
+		queryExecutionIds = append(queryExecutionIds, output.QueryExecutionIds...)
+	}
+
+	queryExecutionIdChunks := chunks(queryExecutionIds, 50)
+	g, getQueryExecutionCtx := errgroup.WithContext(ctx)
+
+	ttlTime := time.Now().Add(-ttl)
+	var mu sync.Mutex
+
+	var latestQueryExecution *types.QueryExecution
+
+	for _, value := range queryExecutionIdChunks {
+		value := value
+		g.Go(func() error {
+			result, err := c.svc.BatchGetQueryExecution(getQueryExecutionCtx, &athena.BatchGetQueryExecutionInput{
+				QueryExecutionIds: value,
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, v := range result.QueryExecutions {
+				// Different query
+				if !strings.Contains(*v.Query, key) {
+					continue
+				}
+
+				// Query didn't completed
+				if v.Status.CompletionDateTime == nil {
+					continue
+				}
+
+				// Query already expired
+				if v.Status.CompletionDateTime.Before(ttlTime) {
+					continue
+				}
+
+				mu.Lock()
+
+				// Store the latest query result
+				if latestQueryExecution == nil {
+					latestQueryExecution = &v
+				} else {
+					if v.Status.CompletionDateTime.After(*latestQueryExecution.Status.CompletionDateTime) {
+						latestQueryExecution = &v
+					}
+				}
+
+				mu.Unlock()
+			}
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return latestQueryExecution, nil
+}

--- a/plugin/s3spanstore/athena_query_cache_test.go
+++ b/plugin/s3spanstore/athena_query_cache_test.go
@@ -1,0 +1,260 @@
+package s3spanstore
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-hclog"
+	"github.com/johanneswuerbach/jaeger-s3/plugin/s3spanstore/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewTestAthenaQueryCache(mockSvc *mocks.MockAthenaAPI) *AthenaQueryCache {
+	loggerName := "jaeger-s3"
+
+	logLevel := os.Getenv("GRPC_STORAGE_PLUGIN_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hclog.Debug.String()
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.LevelFromString(logLevel),
+		Name:       loggerName,
+		JSONFormat: true,
+	})
+
+	return NewAthenaQueryCache(logger, mockSvc, "jaeger")
+}
+
+func TestNoResults(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{}, nil)
+	cache := NewTestAthenaQueryCache(mockSvc)
+
+	cachedQuery, err := cache.Lookup(ctx, "test", time.Second*60)
+
+	assert.NoError(err)
+	assert.Nil(cachedQuery)
+}
+
+func TestOneFinishedResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	validQueryID := "get-services"
+	invalidQueryID := "different"
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{
+			QueryExecutionIds: []string{invalidQueryID, validQueryID},
+		}, nil)
+
+	mockSvc.EXPECT().BatchGetQueryExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.BatchGetQueryExecutionInput, _ ...func(*athena.Options)) (*athena.BatchGetQueryExecutionOutput, error) {
+			assert.Equal([]string{invalidQueryID, validQueryID}, input.QueryExecutionIds)
+
+			return &athena.BatchGetQueryExecutionOutput{
+				QueryExecutions: []types.QueryExecution{
+					{
+						Query:            aws.String("asdas"),
+						QueryExecutionId: aws.String(invalidQueryID),
+						Status: &types.QueryExecutionStatus{
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String(validQueryID),
+						Status: &types.QueryExecutionStatus{
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+							CompletionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+				},
+			}, nil
+		})
+
+	cache := NewTestAthenaQueryCache(mockSvc)
+
+	cachedQuery, err := cache.Lookup(ctx, "service_name, operation_name", time.Second*60)
+
+	assert.NoError(err)
+	assert.NotNil(cachedQuery)
+	assert.Equal(validQueryID, *cachedQuery.QueryExecutionId)
+}
+
+func TestOnePendingResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	validQueryID := "get-services"
+	validPreviousQueryID := "get-services-old"
+	invalidQueryID := "different"
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{
+			QueryExecutionIds: []string{invalidQueryID, validQueryID, validPreviousQueryID},
+		}, nil)
+
+	mockSvc.EXPECT().BatchGetQueryExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.BatchGetQueryExecutionInput, _ ...func(*athena.Options)) (*athena.BatchGetQueryExecutionOutput, error) {
+			assert.Equal([]string{invalidQueryID, validQueryID, validPreviousQueryID}, input.QueryExecutionIds)
+
+			return &athena.BatchGetQueryExecutionOutput{
+				QueryExecutions: []types.QueryExecution{
+					{
+						Query:            aws.String("asdas"),
+						QueryExecutionId: aws.String(invalidQueryID),
+						Status: &types.QueryExecutionStatus{
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String(validQueryID),
+						Status: &types.QueryExecutionStatus{
+							CompletionDateTime: nil,
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String(validPreviousQueryID),
+						Status: &types.QueryExecutionStatus{
+							CompletionDateTime: aws.Time(time.Now().UTC()),
+							SubmissionDateTime: aws.Time(time.Now().UTC().Add(-10 * time.Second)),
+						},
+					},
+				},
+			}, nil
+		})
+
+	cache := NewTestAthenaQueryCache(mockSvc)
+
+	cachedQuery, err := cache.Lookup(ctx, "service_name, operation_name", time.Second*60)
+
+	assert.NoError(err)
+	assert.NotNil(cachedQuery)
+	assert.Equal(validQueryID, *cachedQuery.QueryExecutionId)
+}
+
+func TestOneStaleResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expiredQueryID := "get-services"
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{
+			QueryExecutionIds: []string{expiredQueryID},
+		}, nil)
+
+	mockSvc.EXPECT().BatchGetQueryExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.BatchGetQueryExecutionInput, _ ...func(*athena.Options)) (*athena.BatchGetQueryExecutionOutput, error) {
+			assert.Equal([]string{expiredQueryID}, input.QueryExecutionIds)
+
+			return &athena.BatchGetQueryExecutionOutput{
+				QueryExecutions: []types.QueryExecution{
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String(expiredQueryID),
+						Status: &types.QueryExecutionStatus{
+							CompletionDateTime: nil,
+							SubmissionDateTime: aws.Time(time.Now().UTC().Add(-time.Second * 90)),
+						},
+					},
+				},
+			}, nil
+		})
+
+	cache := NewTestAthenaQueryCache(mockSvc)
+
+	cachedQuery, err := cache.Lookup(ctx, "service_name, operation_name", time.Second*60)
+
+	assert.NoError(err)
+	assert.Nil(cachedQuery)
+}
+
+func TestEarlyExitWithMultiplePages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	queryID := "get-services"
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	first := true
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ *athena.ListQueryExecutionsInput, _ ...func(*athena.Options)) (*athena.ListQueryExecutionsOutput, error) {
+			time.Sleep(time.Millisecond * 200)
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
+			if first {
+				first = false
+				return &athena.ListQueryExecutionsOutput{
+					NextToken:         aws.String("next"),
+					QueryExecutionIds: []string{queryID},
+				}, nil
+			} else {
+				return &athena.ListQueryExecutionsOutput{
+					QueryExecutionIds: []string{},
+				}, nil
+			}
+		}).Times(2)
+
+	mockSvc.EXPECT().BatchGetQueryExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.BatchGetQueryExecutionInput, _ ...func(*athena.Options)) (*athena.BatchGetQueryExecutionOutput, error) {
+			assert.Equal([]string{queryID}, input.QueryExecutionIds)
+
+			return &athena.BatchGetQueryExecutionOutput{
+				QueryExecutions: []types.QueryExecution{
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String(queryID),
+						Status: &types.QueryExecutionStatus{
+							CompletionDateTime: nil,
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+				},
+			}, nil
+		})
+
+	cache := NewTestAthenaQueryCache(mockSvc)
+
+	cachedQuery, err := cache.Lookup(ctx, "service_name, operation_name", time.Second*60)
+
+	assert.NoError(err)
+	assert.NotNil(cachedQuery)
+}

--- a/plugin/s3spanstore/reader.go
+++ b/plugin/s3spanstore/reader.go
@@ -51,7 +51,7 @@ func NewReader(logger hclog.Logger, svc AthenaAPI, cfg config.Athena) (*Reader, 
 		maxSpanAge:           maxSpanAge,
 		dependenciesQueryTTL: dependenciesQueryTTL,
 		servicesQueryTTL:     servicesQueryTTL,
-		athenaQueryCache:     NewAthenaQueryCache(svc, cfg.WorkGroup),
+		athenaQueryCache:     NewAthenaQueryCache(logger, svc, cfg.WorkGroup),
 	}, nil
 }
 
@@ -409,23 +409,4 @@ func (r *Reader) fetchQueryResult(ctx context.Context, queryExecutionId *string)
 	}
 
 	return rows, nil
-}
-
-// From https://stackoverflow.com/a/67011816/2148473
-func chunks(xs []string, chunkSize int) [][]string {
-	if len(xs) == 0 {
-		return nil
-	}
-	divided := make([][]string, (len(xs)+chunkSize-1)/chunkSize)
-	prev := 0
-	i := 0
-	till := len(xs) - chunkSize
-	for prev < till {
-		next := prev + chunkSize
-		divided[i] = xs[prev:next]
-		prev = next
-		i++
-	}
-	divided[i] = xs[prev:]
-	return divided
 }

--- a/plugin/s3spanstore/reader.go
+++ b/plugin/s3spanstore/reader.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/athena"
@@ -16,7 +15,6 @@ import (
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/johanneswuerbach/jaeger-s3/plugin/config"
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/sync/errgroup"
 )
 
 // mockgen -destination=./plugin/s3spanstore/mocks/mock_athena.go -package=mocks github.com/johanneswuerbach/jaeger-s3/plugin/s3spanstore AthenaAPI
@@ -53,6 +51,7 @@ func NewReader(logger hclog.Logger, svc AthenaAPI, cfg config.Athena) (*Reader, 
 		maxSpanAge:           maxSpanAge,
 		dependenciesQueryTTL: dependenciesQueryTTL,
 		servicesQueryTTL:     servicesQueryTTL,
+		athenaQueryCache:     NewAthenaQueryCache(svc, cfg.WorkGroup),
 	}, nil
 }
 
@@ -63,6 +62,7 @@ type Reader struct {
 	maxSpanAge           time.Duration
 	dependenciesQueryTTL time.Duration
 	servicesQueryTTL     time.Duration
+	athenaQueryCache     *AthenaQueryCache
 }
 
 const (
@@ -328,122 +328,70 @@ func (r *Reader) GetDependencies(ctx context.Context, endTs time.Time, lookback 
 }
 
 func (r *Reader) queryAthenaCached(ctx context.Context, queryString string, lookupString string, ttl time.Duration) ([]types.Row, error) {
-	paginator := athena.NewListQueryExecutionsPaginator(r.svc, &athena.ListQueryExecutionsInput{
-		WorkGroup: &r.cfg.WorkGroup,
-	})
-	queryExecutionIds := []string{}
-	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get athena query result: %w", err)
-		}
-
-		queryExecutionIds = append(queryExecutionIds, output.QueryExecutionIds...)
+	queryExecution, err := r.athenaQueryCache.Lookup(ctx, lookupString, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup cached athena query: %w", err)
 	}
 
-	queryExecutionIdChunks := chunks(queryExecutionIds, 50)
-	g, getQueryExecutionCtx := errgroup.WithContext(ctx)
-
-	ttlTime := time.Now().Add(-ttl)
-	var mu sync.Mutex
-
-	latestCompletionDateTime := time.Now()
-	latestQueryExecutionId := ""
-
-	for _, value := range queryExecutionIdChunks {
-		value := value
-		g.Go(func() error {
-			result, err := r.svc.BatchGetQueryExecution(getQueryExecutionCtx, &athena.BatchGetQueryExecutionInput{
-				QueryExecutionIds: value,
-			})
-			if err != nil {
-				return err
-			}
-
-			for _, v := range result.QueryExecutions {
-				// Different query
-				if !strings.Contains(*v.Query, lookupString) {
-					continue
-				}
-
-				// Query didn't completed
-				if v.Status.CompletionDateTime == nil {
-					continue
-				}
-
-				// Query already expired
-				if v.Status.CompletionDateTime.Before(ttlTime) {
-					continue
-				}
-
-				mu.Lock()
-
-				// Store the latest query result
-				if latestQueryExecutionId == "" {
-					latestQueryExecutionId = *v.QueryExecutionId
-					latestCompletionDateTime = *v.Status.CompletionDateTime
-				} else {
-					if v.Status.CompletionDateTime.After(latestCompletionDateTime) {
-						latestQueryExecutionId = *v.QueryExecutionId
-						latestCompletionDateTime = *v.Status.CompletionDateTime
-					}
-				}
-
-				mu.Unlock()
-			}
-
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-
-	if latestQueryExecutionId != "" {
-		return r.fetchQueryResult(ctx, latestQueryExecutionId)
+	if queryExecution != nil {
+		return r.waitAndFetchQueryResult(ctx, queryExecution)
 	}
 
 	return r.queryAthena(ctx, queryString)
 }
 
-func (s *Reader) queryAthena(ctx context.Context, queryString string) ([]types.Row, error) {
-	output, err := s.svc.StartQueryExecution(ctx, &athena.StartQueryExecutionInput{
+func (r *Reader) queryAthena(ctx context.Context, queryString string) ([]types.Row, error) {
+	output, err := r.svc.StartQueryExecution(ctx, &athena.StartQueryExecutionInput{
 		QueryString: &queryString,
 		QueryExecutionContext: &types.QueryExecutionContext{
-			Database: &s.cfg.DatabaseName,
+			Database: &r.cfg.DatabaseName,
 		},
 		ResultConfiguration: &types.ResultConfiguration{
-			OutputLocation: &s.cfg.OutputLocation,
+			OutputLocation: &r.cfg.OutputLocation,
 		},
-		WorkGroup: &s.cfg.WorkGroup,
+		WorkGroup: &r.cfg.WorkGroup,
 	})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to start athena query: %w", err)
 	}
 
+	status, err := r.svc.GetQueryExecution(ctx, &athena.GetQueryExecutionInput{
+		QueryExecutionId: output.QueryExecutionId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get athena query execution: %w", err)
+	}
+
+	return r.waitAndFetchQueryResult(ctx, status.QueryExecution)
+}
+
+func (r *Reader) waitAndFetchQueryResult(ctx context.Context, queryExecution *types.QueryExecution) ([]types.Row, error) {
 	// Poll until the query completed
 	for {
-		status, err := s.svc.GetQueryExecution(ctx, &athena.GetQueryExecutionInput{
-			QueryExecutionId: output.QueryExecutionId,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get athena query execution: %w", err)
-		}
-		if status.QueryExecution.Status.CompletionDateTime != nil {
+		if queryExecution.Status.CompletionDateTime != nil {
 			break
 		}
 
 		time.Sleep(100 * time.Millisecond)
+
+		status, err := r.svc.GetQueryExecution(ctx, &athena.GetQueryExecutionInput{
+			QueryExecutionId: queryExecution.QueryExecutionId,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get athena query execution: %w", err)
+		}
+
+		queryExecution = status.QueryExecution
 	}
 
-	return s.fetchQueryResult(ctx, *output.QueryExecutionId)
+	return r.fetchQueryResult(ctx, queryExecution.QueryExecutionId)
 }
 
-func (r *Reader) fetchQueryResult(ctx context.Context, queryExecutionId string) ([]types.Row, error) {
+func (r *Reader) fetchQueryResult(ctx context.Context, queryExecutionId *string) ([]types.Row, error) {
 	// Get query results
 	paginator := athena.NewGetQueryResultsPaginator(r.svc, &athena.GetQueryResultsInput{
-		QueryExecutionId: &queryExecutionId,
+		QueryExecutionId: queryExecutionId,
 	})
 	rows := []types.Row{}
 	for paginator.HasMorePages() {

--- a/plugin/s3spanstore/reader_test.go
+++ b/plugin/s3spanstore/reader_test.go
@@ -134,12 +134,16 @@ func TestGetServicesCached(t *testing.T) {
 				QueryExecutions: []types.QueryExecution{
 					{
 						Query:            aws.String("asdas"),
-						QueryExecutionId: aws.String("different"),
+						QueryExecutionId: aws.String(invalidQueryID),
+						Status: &types.QueryExecutionStatus{
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
+						},
 					},
 					{
 						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
-						QueryExecutionId: aws.String("get-services"),
+						QueryExecutionId: aws.String(validQueryID),
 						Status: &types.QueryExecutionStatus{
+							SubmissionDateTime: aws.Time(time.Now().UTC()),
 							CompletionDateTime: aws.Time(time.Now().UTC()),
 						},
 					},

--- a/plugin/s3spanstore/reader_test.go
+++ b/plugin/s3spanstore/reader_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-hclog"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/johanneswuerbach/jaeger-s3/plugin/config"
 	"github.com/johanneswuerbach/jaeger-s3/plugin/s3spanstore/mocks"
 	"github.com/stretchr/testify/assert"
@@ -44,17 +46,28 @@ func NewTestReader(ctx context.Context, assert *assert.Assertions, mockSvc *mock
 	return reader
 }
 
-func TestGetServices(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func toAthenaResultSet(results [][]string) *types.ResultSet {
+	resultsRows := make([]types.Row, len(results)+1)
+	resultsRows[0] = types.Row{} // Header row, usually ignored by the reader
+	for i, row := range results {
+		row := row
 
+		rowValues := make([]types.Datum, len(row))
+		for i, columnValue := range row {
+			columnValue := columnValue
+			rowValues[i] = types.Datum{VarCharValue: &columnValue}
+		}
+
+		resultsRows[i+1] = types.Row{Data: rowValues}
+	}
+
+	return &types.ResultSet{Rows: resultsRows}
+}
+
+func mockQueryRunAndResult(mockSvc *mocks.MockAthenaAPI, result [][]string) {
 	queryID := "queryId"
 	now := time.Now()
-	serviceName := "test"
 
-	mockSvc := mocks.NewMockAthenaAPI(ctrl)
-	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
-		Return(&athena.ListQueryExecutionsOutput{}, nil)
 	mockSvc.EXPECT().StartQueryExecution(gomock.Any(), gomock.Any()).
 		Return(&athena.StartQueryExecutionOutput{
 			QueryExecutionId: &queryID,
@@ -67,18 +80,23 @@ func TestGetServices(t *testing.T) {
 				},
 			},
 		}, nil)
-
 	mockSvc.EXPECT().GetQueryResults(gomock.Any(), gomock.Any()).
 		Return(&athena.GetQueryResultsOutput{
-			ResultSet: &types.ResultSet{
-				Rows: []types.Row{
-					{},
-					{Data: []types.Datum{
-						{VarCharValue: &serviceName},
-					}},
-				},
-			},
+			ResultSet: toAthenaResultSet(result),
 		}, nil)
+}
+
+func TestGetServices(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	serviceName := "test"
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{}, nil)
+
+	mockQueryRunAndResult(mockSvc, [][]string{{serviceName}})
 
 	assert := assert.New(t)
 	ctx := context.TODO()
@@ -89,4 +107,151 @@ func TestGetServices(t *testing.T) {
 
 	assert.NoError(err)
 	assert.Equal([]string{serviceName}, services)
+}
+
+func TestGetServicesCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	serviceName := "test"
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	validQueryID := "get-services"
+	invalidQueryID := "different"
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{
+			QueryExecutionIds: []string{invalidQueryID, validQueryID},
+		}, nil)
+
+	mockSvc.EXPECT().BatchGetQueryExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.BatchGetQueryExecutionInput, _ ...func(*athena.Options)) (*athena.BatchGetQueryExecutionOutput, error) {
+			assert.Equal([]string{invalidQueryID, validQueryID}, input.QueryExecutionIds)
+
+			return &athena.BatchGetQueryExecutionOutput{
+				QueryExecutions: []types.QueryExecution{
+					{
+						Query:            aws.String("asdas"),
+						QueryExecutionId: aws.String("different"),
+					},
+					{
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						QueryExecutionId: aws.String("get-services"),
+						Status: &types.QueryExecutionStatus{
+							CompletionDateTime: aws.Time(time.Now().UTC()),
+						},
+					},
+				},
+			}, nil
+		})
+
+	mockSvc.EXPECT().GetQueryResults(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *athena.GetQueryResultsInput, _ ...func(*athena.Options)) (*athena.GetQueryResultsOutput, error) {
+			assert.Equal("get-services", *input.QueryExecutionId)
+
+			return &athena.GetQueryResultsOutput{
+				ResultSet: toAthenaResultSet([][]string{{serviceName}}),
+			}, nil
+		})
+
+	reader := NewTestReader(ctx, assert, mockSvc)
+
+	services, err := reader.GetServices(ctx)
+
+	assert.NoError(err)
+	assert.Equal([]string{serviceName}, services)
+}
+
+func TestGetOperations(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	results := [][]string{
+		{
+			"test",
+			"server-op",
+			"server",
+		},
+		{
+			"test",
+			"client-op",
+			"client",
+		},
+		{
+			"different",
+			"server-op",
+			"server",
+		},
+	}
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{}, nil)
+
+	mockQueryRunAndResult(mockSvc, results)
+
+	reader := NewTestReader(ctx, assert, mockSvc)
+
+	operations, err := reader.GetOperations(ctx, spanstore.OperationQueryParameters{ServiceName: "test", SpanKind: ""})
+
+	assert.NoError(err)
+	assert.Equal([]spanstore.Operation{
+		{
+			Name:     "server-op",
+			SpanKind: "server",
+		},
+		{
+			Name:     "client-op",
+			SpanKind: "client",
+		},
+	}, operations)
+}
+
+func TestGetOperationsWithSpanKind(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	results := [][]string{
+		{
+			"test",
+			"server-op",
+			"server",
+		},
+		{
+			"test",
+			"client-op",
+			"client",
+		},
+		{
+			"different",
+			"server-op",
+			"server",
+		},
+	}
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	mockSvc := mocks.NewMockAthenaAPI(ctrl)
+	mockSvc.EXPECT().ListQueryExecutions(gomock.Any(), gomock.Any()).
+		Return(&athena.ListQueryExecutionsOutput{}, nil)
+
+	mockQueryRunAndResult(mockSvc, results)
+
+	reader := NewTestReader(ctx, assert, mockSvc)
+
+	operations, err := reader.GetOperations(ctx, spanstore.OperationQueryParameters{ServiceName: "test", SpanKind: "server"})
+
+	assert.NoError(err)
+	assert.Equal([]spanstore.Operation{
+		{
+			Name:     "server-op",
+			SpanKind: "server",
+		},
+	}, operations)
 }


### PR DESCRIPTION
use the fact that the executions are ordered and re-use still running queries