### PR TITLE
feat: store operations in a separate table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,7 @@ lint: ## Lint the code
 
 bench: ## Run jaeger plugin benchmarks
 	docker compose run --rm test go test -benchmem -bench=. ./...
+
+.PHONY: setup
+setup: ## Run the setup
+	go run setup/setup.go

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4
 	github.com/hashicorp/go-hclog v1.1.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jaegertracing/jaeger v1.31.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/ory/viper v1.7.5

--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,7 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/plugin/config/config.go
+++ b/plugin/config/config.go
@@ -1,15 +1,19 @@
 package config
 
 type S3 struct {
-	BucketName     string
-	Prefix         string
-	BufferDuration string
-	EmptyBucket    bool
+	BucketName                string
+	SpansPrefix               string
+	OperationsPrefix          string
+	BufferDuration            string
+	EmptyBucket               bool
+	OperationsDedupeDuration  string
+	OperationsDedupeCacheSize int
 }
 
 type Athena struct {
 	DatabaseName         string
-	TableName            string
+	SpansTableName       string
+	OperationsTableName  string
 	WorkGroup            string
 	OutputLocation       string
 	MaxSpanAge           string

--- a/plugin/s3spanstore/dedupe_parquet_writer.go
+++ b/plugin/s3spanstore/dedupe_parquet_writer.go
@@ -1,0 +1,48 @@
+package s3spanstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+type DedupeParquetWriter struct {
+	logger         hclog.Logger
+	dedupeCache    *lru.Cache
+	dedupeDuration time.Duration
+	parquetWriter  IParquetWriter
+}
+
+func NewDedupeParquetWriter(logger hclog.Logger, dedupeDuration time.Duration, dedupeCacheSize int, parquetWriter IParquetWriter) (*DedupeParquetWriter, error) {
+	dedupeCache, err := lru.New(dedupeCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service cache, %v", err)
+	}
+
+	w := &DedupeParquetWriter{
+		logger:         logger,
+		dedupeCache:    dedupeCache,
+		dedupeDuration: dedupeDuration,
+		parquetWriter:  parquetWriter,
+	}
+
+	return w, nil
+}
+
+func (w *DedupeParquetWriter) Write(ctx context.Context, rowTime time.Time, row interface{}) error {
+	if nextWriteTime, ok := w.dedupeCache.Get(row); !ok || rowTime.After(nextWriteTime.(time.Time)) {
+		if err := w.parquetWriter.Write(ctx, rowTime, row); err != nil {
+			return fmt.Errorf("failed to write row: %w", err)
+		}
+		w.dedupeCache.Add(row, rowTime.Add(w.dedupeDuration))
+	}
+
+	return nil
+}
+
+func (w *DedupeParquetWriter) Close() error {
+	return w.parquetWriter.Close()
+}

--- a/plugin/s3spanstore/dedupe_parquet_writer_test.go
+++ b/plugin/s3spanstore/dedupe_parquet_writer_test.go
@@ -1,0 +1,87 @@
+package s3spanstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewTestDedupeParquetWriter(assert *assert.Assertions, parquetWriter IParquetWriter) *DedupeParquetWriter {
+	loggerName := "jaeger-s3"
+
+	logLevel := os.Getenv("GRPC_STORAGE_PLUGIN_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hclog.Debug.String()
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.LevelFromString(logLevel),
+		Name:       loggerName,
+		JSONFormat: true,
+	})
+
+	writer, err := NewDedupeParquetWriter(logger, 100*time.Millisecond, 100, parquetWriter)
+	assert.NoError(err)
+
+	return writer
+}
+
+type testWriter struct {
+	writes []interface{}
+}
+
+func (w *testWriter) Write(ctx context.Context, time time.Time, row interface{}) error {
+	fmt.Println("Write", row)
+	w.writes = append(w.writes, row)
+	return nil
+}
+
+func (w *testWriter) Close() error {
+	return nil
+}
+
+type operation struct {
+	name string
+}
+
+func TestDedupeParquetWriter(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	testWriter := &testWriter{writes: []interface{}{}}
+	writer := NewTestDedupeParquetWriter(assert, testWriter)
+
+	time := time.Now()
+
+	assert.NoError(writer.Write(ctx, time, operation{name: "a"}))
+	assert.NoError(writer.Write(ctx, time, operation{name: "a"}))
+	assert.NoError(writer.Write(ctx, time, operation{name: "b"}))
+
+	assert.Equal([]interface{}{
+		operation{name: "a"},
+		operation{name: "b"},
+	}, testWriter.writes)
+}
+
+func TestDedupeParquetWriterWritesAgain(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	testWriter := &testWriter{writes: []interface{}{}}
+	writer := NewTestDedupeParquetWriter(assert, testWriter)
+
+	timeNow := time.Now()
+
+	assert.NoError(writer.Write(ctx, timeNow, operation{name: "a"}))
+	assert.NoError(writer.Write(ctx, timeNow.Add(200*time.Millisecond), operation{name: "a"}))
+
+	assert.Equal([]interface{}{
+		operation{name: "a"},
+		operation{name: "a"},
+	}, testWriter.writes)
+}

--- a/plugin/s3spanstore/operationrecord.go
+++ b/plugin/s3spanstore/operationrecord.go
@@ -1,0 +1,22 @@
+package s3spanstore
+
+import (
+	"github.com/jaegertracing/jaeger/model"
+)
+
+// OperationRecord contains queryable properties
+type OperationRecord struct {
+	OperationName string `parquet:"name=operation_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	SpanKind      string `parquet:"name=span_kind, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	ServiceName   string `parquet:"name=service_name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+}
+
+func NewOperationRecordFromSpan(span *model.Span) (*OperationRecord, error) {
+	kind, _ := span.GetSpanKind()
+
+	return &OperationRecord{
+		OperationName: span.OperationName,
+		SpanKind:      kind,
+		ServiceName:   span.Process.ServiceName,
+	}, nil
+}

--- a/plugin/s3spanstore/parquet_writer.go
+++ b/plugin/s3spanstore/parquet_writer.go
@@ -54,6 +54,11 @@ type ParquetWriter struct {
 	ctx               context.Context
 }
 
+type IParquetWriter interface {
+	Write(ctx context.Context, time time.Time, row interface{}) error
+	Close() error
+}
+
 func NewParquetWriter(ctx context.Context, logger hclog.Logger, svc S3API, bufferDuration time.Duration, bucketName string, prefix string) (*ParquetWriter, error) {
 	w := &ParquetWriter{
 		svc:               svc,

--- a/plugin/s3spanstore/parquet_writer.go
+++ b/plugin/s3spanstore/parquet_writer.go
@@ -1,0 +1,175 @@
+package s3spanstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/xitongsys/parquet-go-source/s3v2"
+	"github.com/xitongsys/parquet-go/source"
+	"github.com/xitongsys/parquet-go/writer"
+)
+
+const (
+	PARQUET_CONCURRENCY = 1
+	PARTION_FORMAT      = "2006/01/02/15"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func S3ParquetKey(prefix, suffix string, datehour string) string {
+	return prefix + datehour + "/" + suffix + ".parquet"
+}
+
+func S3PartitionKey(t time.Time) string {
+	return t.Format(PARTION_FORMAT)
+}
+
+type ParquetRef struct {
+	parquetWriteFile source.ParquetFile
+	parquetWriter    *writer.ParquetWriter
+}
+
+type ParquetWriter struct {
+	logger     hclog.Logger
+	svc        S3API
+	bucketName string
+	prefix     string
+	ticker     *time.Ticker
+	done       chan bool
+
+	parquetWriterRefs map[string]*ParquetRef
+	bufferMutex       sync.Mutex
+	ctx               context.Context
+}
+
+func NewParquetWriter(ctx context.Context, logger hclog.Logger, svc S3API, bufferDuration time.Duration, bucketName string, prefix string) (*ParquetWriter, error) {
+	w := &ParquetWriter{
+		svc:               svc,
+		bucketName:        bucketName,
+		prefix:            prefix,
+		logger:            logger,
+		ticker:            time.NewTicker(bufferDuration),
+		done:              make(chan bool),
+		parquetWriterRefs: map[string]*ParquetRef{},
+		ctx:               ctx,
+	}
+
+	go func() {
+		for {
+			select {
+			case <-w.done:
+				return
+			case <-w.ticker.C:
+				if err := w.rotateParquetWriters(); err != nil {
+					w.logger.Error("failed to rotate parquet writer", err)
+				}
+			}
+		}
+	}()
+
+	return w, nil
+}
+
+func (w *ParquetWriter) getParquetWriter(datehour string) (*writer.ParquetWriter, error) {
+	if w.parquetWriterRefs[datehour] != nil {
+		return w.parquetWriterRefs[datehour].parquetWriter, nil
+	}
+
+	writeFile, err := s3v2.NewS3FileWriterWithClient(w.ctx, w.svc, w.bucketName, w.parquetKey(datehour), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create parquet s3 client: %w", err)
+	}
+
+	parquetWriter, err := writer.NewParquetWriter(writeFile, new(SpanRecord), PARQUET_CONCURRENCY)
+	if err != nil {
+		writeFile.Close()
+		return nil, fmt.Errorf("failed to create parquet writer: %w", err)
+	}
+
+	w.parquetWriterRefs[datehour] = &ParquetRef{
+		parquetWriteFile: writeFile,
+		parquetWriter:    parquetWriter,
+	}
+
+	return parquetWriter, nil
+}
+
+func (w *ParquetWriter) parquetKey(datehour string) string {
+	return S3ParquetKey(w.prefix, RandStringBytes(32), datehour)
+}
+
+func (w *ParquetWriter) closeParquetWriter(parquetRef *ParquetRef) error {
+	if parquetRef.parquetWriter != nil {
+		if err := parquetRef.parquetWriter.WriteStop(); err != nil {
+			return fmt.Errorf("parquet write stop error: %w", err)
+		}
+	}
+
+	if parquetRef.parquetWriteFile != nil {
+		if err := parquetRef.parquetWriteFile.Close(); err != nil {
+			return fmt.Errorf("parquet file write close error: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *ParquetWriter) rotateParquetWriters() error {
+	w.bufferMutex.Lock()
+
+	writerRefs := w.parquetWriterRefs
+	w.parquetWriterRefs = map[string]*ParquetRef{}
+
+	w.bufferMutex.Unlock()
+
+	return w.closeParquetWriters(writerRefs)
+}
+
+func (w *ParquetWriter) closeParquetWriters(parquetWriterRefs map[string]*ParquetRef) error {
+	for _, writerRef := range parquetWriterRefs {
+		if err := w.closeParquetWriter(writerRef); err != nil {
+			return fmt.Errorf("failed to close previous parquet writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *ParquetWriter) Write(ctx context.Context, time time.Time, row interface{}) error {
+	w.bufferMutex.Lock()
+	defer w.bufferMutex.Unlock()
+
+	spanDatehour := S3PartitionKey(time)
+
+	parquetWriter, err := w.getParquetWriter(spanDatehour)
+	if err != nil {
+		return fmt.Errorf("failed to get parquet writer: %w", err)
+	}
+
+	if err := parquetWriter.Write(row); err != nil {
+		return fmt.Errorf("failed to write row: %w", err)
+	}
+	return nil
+}
+
+func (w *ParquetWriter) Close() error {
+	w.ticker.Stop()
+	w.done <- true
+
+	w.bufferMutex.Lock()
+	defer w.bufferMutex.Unlock()
+
+	return w.closeParquetWriters(w.parquetWriterRefs)
+}

--- a/plugin/s3spanstore/parquet_writer_test.go
+++ b/plugin/s3spanstore/parquet_writer_test.go
@@ -1,0 +1,62 @@
+package s3spanstore
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-hclog"
+	"github.com/johanneswuerbach/jaeger-s3/plugin/s3spanstore/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewTestParquetWriter(ctx context.Context, assert *assert.Assertions, mockSvc *mocks.MockS3API) *ParquetWriter {
+	loggerName := "jaeger-s3"
+
+	logLevel := os.Getenv("GRPC_STORAGE_PLUGIN_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hclog.Debug.String()
+	}
+
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.LevelFromString(logLevel),
+		Name:       loggerName,
+		JSONFormat: true,
+	})
+
+	writer, err := NewParquetWriter(ctx, logger, mockSvc, time.Millisecond*200, "jaeger-spans", "/spans/")
+
+	assert.NoError(err)
+
+	return writer
+}
+
+func TestWriteSpanAndRotate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSvc := mocks.NewMockS3API(ctrl)
+	mockSvc.EXPECT().PutObject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.PutObjectOutput{}, nil).Times(2)
+
+	assert := assert.New(t)
+	ctx := context.TODO()
+
+	writer := NewTestParquetWriter(ctx, assert, mockSvc)
+
+	span := NewTestSpan(assert)
+
+	spanRecord, err := NewSpanRecordFromSpan(span)
+	assert.NoError(err)
+
+	assert.NoError(writer.Write(ctx, span.StartTime, spanRecord))
+
+	time.Sleep(time.Millisecond * 500)
+
+	assert.NoError(writer.Write(ctx, span.StartTime, spanRecord))
+
+	assert.NoError(writer.Close())
+}

--- a/plugin/s3spanstore/reader_test.go
+++ b/plugin/s3spanstore/reader_test.go
@@ -33,7 +33,8 @@ func NewTestReader(ctx context.Context, assert *assert.Assertions, mockSvc *mock
 
 	reader, err := NewReader(logger, mockSvc, config.Athena{
 		DatabaseName:         "default",
-		TableName:            "jaeger",
+		SpansTableName:       "jaeger_spans",
+		OperationsTableName:  "jaeger_operations",
 		OutputLocation:       "s3://jaeger-s3-test-results/",
 		WorkGroup:            "jaeger",
 		MaxSpanAge:           "336h",
@@ -140,7 +141,7 @@ func TestGetServicesCached(t *testing.T) {
 						},
 					},
 					{
-						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger" WHERE`),
+						Query:            aws.String(`SELECT service_name, operation_name, span_kind FROM "jaeger_operations" WHERE`),
 						QueryExecutionId: aws.String(validQueryID),
 						Status: &types.QueryExecutionStatus{
 							SubmissionDateTime: aws.Time(time.Now().UTC()),

--- a/plugin/s3spanstore/writer_test.go
+++ b/plugin/s3spanstore/writer_test.go
@@ -214,7 +214,7 @@ func TestWriteSpanAndRotate(t *testing.T) {
 
 	assert.NoError(writer.WriteSpan(ctx, span))
 
-	assert.NoError(writer.rotateParquetWriters())
+	assert.NoError(writer.spanParquetWriter.rotateParquetWriters())
 
 	assert.NoError(writer.WriteSpan(ctx, span))
 

--- a/plugin/s3spanstore/writer_test.go
+++ b/plugin/s3spanstore/writer_test.go
@@ -35,8 +35,9 @@ func NewTestWriter(ctx context.Context, assert *assert.Assertions, mockSvc *mock
 	})
 
 	writer, err := NewWriter(logger, mockSvc, config.S3{
-		BucketName: "jaeger-spans",
-		Prefix:     "/spans/",
+		BucketName:       "jaeger-spans",
+		SpansPrefix:      "/spans/",
+		OperationsPrefix: "/operations/",
 	})
 
 	assert.NoError(err)
@@ -157,7 +158,7 @@ func TestWriteSpan(t *testing.T) {
 			assert.NoError(ioutil.WriteFile(file.Name(), dat, 0644))
 
 			return &s3.PutObjectOutput{}, nil
-		})
+		}).Times(2)
 
 	writer := NewTestWriter(ctx, assert, mockSvc)
 
@@ -195,32 +196,6 @@ func TestWriteSpan(t *testing.T) {
 	assert.NoError(localFileReader.Close())
 }
 
-func TestWriteSpanAndRotate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockSvc := mocks.NewMockS3API(ctrl)
-	mockSvc.EXPECT().PutObject(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&s3.PutObjectOutput{}, nil).Times(2)
-
-	assert := assert.New(t)
-	ctx := context.TODO()
-
-	writer := NewTestWriter(ctx, assert, mockSvc)
-
-	span := NewTestSpan(assert)
-
-	assert.NoError(writer.WriteSpan(ctx, span))
-
-	assert.NoError(writer.WriteSpan(ctx, span))
-
-	assert.NoError(writer.spanParquetWriter.rotateParquetWriters())
-
-	assert.NoError(writer.WriteSpan(ctx, span))
-
-	assert.NoError(writer.Close())
-}
-
 func TestWriteSpanWithTagsAndReferences(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -241,7 +216,7 @@ func TestWriteSpanWithTagsAndReferences(t *testing.T) {
 			assert.NoError(ioutil.WriteFile(file.Name(), dat, 0644))
 
 			return &s3.PutObjectOutput{}, nil
-		})
+		}).Times(2)
 
 	writer := NewTestWriter(ctx, assert, mockSvc)
 

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,11 +1,14 @@
 s3:
   bucketName: jaeger-s3-test
-  prefix: spans/
+  spansPrefix: spans/
+  operationsPrefix: operations/
   bufferDuration: 1s
+  operationsDedupeDuration: 1s
   emptyBucket: true
 athena:
   databaseName: default
-  tableName: jaeger
+  spansTableName: jaeger_spans
+  operationsTableName: jaeger_operations
   outputLocation: s3://jaeger-s3-test-results/
   workGroup: jaeger
   maxSpanAge: 336h


### PR DESCRIPTION
Querying the span table to determine the service names and operations is too slow as the query by default needs to cover the entire retention timeframe.

Use a second table here, which only stores the operations and deduplicates writes for up to 1h to reduce the amount of objects to be scanned.