### PR TITLE
chore(ci): fix e2e with dependabot

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,31 @@
+name: test-e2e
+on:
+  workflow_run:
+    workflows: ["test"]
+    types:
+      - completed
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-jaeger-grpc-integration:
+    name: test-jaeger-grpc-integration
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS credentials from CI account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::962548656022:role/jaeger-s3-ci
+          aws-region: us-east-1
+      - run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+      - run: make test-jaeger-grpc-integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,22 +24,3 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
           chmod +x ~/.docker/cli-plugins/docker-compose
       - run: make test
-
-  test-jaeger-grpc-integration:
-    name: test-jaeger-grpc-integration
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure AWS credentials from CI account
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::962548656022:role/jaeger-s3-ci
-          aws-region: us-east-1
-      - run: |
-          mkdir -p ~/.docker/cli-plugins/
-          curl -SL https://github.com/docker/compose/releases/download/v2.0.0/docker-compose-linux-amd64 -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
-      - run: make test-jaeger-grpc-integration


### PR DESCRIPTION
Configure actions using https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544 to allow running e2e tests after a PR was approved.