### PR TITLE
feat: increase operations dedupe time

### DIFF
--- a/plugin/s3spanstore/writer.go
+++ b/plugin/s3spanstore/writer.go
@@ -72,7 +72,7 @@ func NewWriter(ctx context.Context, logger hclog.Logger, svc S3API, s3Config con
 		bufferDuration = duration
 	}
 
-	operationsDedupeDuration := time.Hour * 1
+	operationsDedupeDuration := time.Hour * 12
 	if s3Config.OperationsDedupeDuration != "" {
 		duration, err := time.ParseDuration(s3Config.OperationsDedupeDuration)
 		if err != nil {


### PR DESCRIPTION
S3 lifecycle policies run every 24h so writing unique service / operations every 12h is enough to keep them in sync with spans actually available for querying.

Dedupe those further reduces the time required to query for available services and operations.