### PR TITLE
feat: implement stream and close methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func main() {
 
 	logger.Debug("plugin created")
 	grpc.Serve(&shared.PluginServices{
-		Store: s3Plugin,
+		Store:               s3Plugin,
+		StreamingSpanWriter: s3Plugin,
 	})
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,14 +3,23 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/jaegertracing/jaeger/plugin/storage/grpc/shared"
 	"github.com/jaegertracing/jaeger/storage/dependencystore"
 	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/johanneswuerbach/jaeger-s3/plugin/config"
 	"github.com/johanneswuerbach/jaeger-s3/plugin/s3spanstore"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	_ shared.StoragePlugin             = (*S3Plugin)(nil)
+	_ shared.StreamingSpanWriterPlugin = (*S3Plugin)(nil)
+	_ io.Closer                        = (*S3Plugin)(nil)
 )
 
 func NewS3Plugin(ctx context.Context, logger hclog.Logger, s3Svc *s3.Client, s3Config config.S3, athenaSvc *athena.Client, athenaConfig config.Athena) (*S3Plugin, error) {
@@ -48,4 +57,17 @@ func (h *S3Plugin) SpanReader() spanstore.Reader {
 
 func (h *S3Plugin) DependencyReader() dependencystore.Reader {
 	return h.spanReader
+}
+
+func (h *S3Plugin) StreamingSpanWriter() spanstore.Writer {
+	return h.spanWriter
+}
+
+func (h *S3Plugin) Close() error {
+	g := errgroup.Group{}
+
+	g.Go(h.spanWriter.Close)
+	g.Go(h.spanReader.Close)
+
+	return g.Wait()
 }

--- a/plugin/s3spanstore/reader.go
+++ b/plugin/s3spanstore/reader.go
@@ -479,3 +479,8 @@ func (r *Reader) fetchQueryResult(ctx context.Context, queryExecutionId *string)
 
 	return rows, nil
 }
+
+func (r *Reader) Close() error {
+	r.dependenciesPrefetch.Stop()
+	return nil
+}


### PR DESCRIPTION
Implements https://github.com/jaegertracing/jaeger/pull/3640 to lower the resources when streaming spans.

Also implements the close interface to ensure all spans are flushed.

Heavily influenced by https://github.com/jaegertracing/jaeger-clickhouse/pull/110