### PR TITLE
Bail on cache reads when GetBatchExecution contains unprocessed executions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -275,6 +275,7 @@ data "aws_iam_policy_document" "jaeger" {
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
       "athena:GetQueryExecution",
+      "athena:BatchGetQueryExecution",
       "athena:GetQueryResults",
       "athena:ListQueryExecutions",
     ]


### PR DESCRIPTION
Turns out that the setup guide is missing an IAM action for the query cache. This only manifested itself in a channel being permanently (until the request context was cancelled by the client) blocked because the second goroutine already exited, nothing was logged.

Fixed HCL, added logging, added bailing on caching when finding unprocessed IDs.